### PR TITLE
Fix Response#success? to not include WARNING_CODE

### DIFF
--- a/lib/global_sign/response.rb
+++ b/lib/global_sign/response.rb
@@ -23,7 +23,7 @@ module GlobalSign
     end
 
     def error?
-      !success?
+      !success? && !warning?
     end
 
     def error_code


### PR DESCRIPTION
`Response#warning?` が True だった場合の分岐処理が書きづらかったので、 success と warning は分けるようにします。

こうすることで、今まで 
`warning? → success?` の順で条件分岐を書いていたものを
`success? → warning?` とスマートに書けるようになります。
