### PR TITLE
Select SSL certificate type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GlobalSign
 
+[![Gem Version](https://badge.fury.io/rb/global_sign.svg)](https://badge.fury.io/rb/global_sign)
 [![wercker status](https://app.wercker.com/status/8cf8771f0da8bc4f1ea0adc8eb65b295/s/master "wercker status")](https://app.wercker.com/project/byKey/8cf8771f0da8bc4f1ea0adc8eb65b295)
 
 A Ruby interface to the [GlobalSign](https://www.globalsign.com/) API.
@@ -62,6 +63,7 @@ contract = GlobalSign::Contract.new(
 )
 
 request = GlobalSign::UrlVerification::Request.new(
+  product_code:           'DV_LOW_URL',   # 'DV_HIGH_URL' or 'DV_LOW_URL'
   order_kind:             'new',   # If you request a new certificate
   validity_period_months: 6,
   csr:                    csr,
@@ -90,6 +92,7 @@ end
 
 # Not need to give the argument 'contract_info'
 request = GlobalSign::UrlVerification::Request.new(
+  product_code:           'DV_LOW_URL',
   order_kind:             'new',
   validity_period_months: 6,
   csr:                    csr,
@@ -101,6 +104,7 @@ And you should give the argument `renewal_target_order_id` .
 
 ```ruby
 request = GlobalSign::UrlVerification::Request.new(
+  product_code:            'DV_LOW_URL',
   order_kind:              'renewal',
   validity_period_months:  6,
   csr:                     csr,

--- a/lib/global_sign/url_verification/request.rb
+++ b/lib/global_sign/url_verification/request.rb
@@ -1,7 +1,8 @@
 module GlobalSign
   module UrlVerification
     class Request < GlobalSign::Request
-      def initialize(order_kind:, validity_period_months:, csr:, renewal_target_order_id: nil, contract_info: nil)
+      def initialize(product_code:, order_kind:, validity_period_months:, csr:, renewal_target_order_id: nil, contract_info: nil)
+        @product_code            = product_code
         @order_kind              = order_kind
         @validity_period_months  = validity_period_months
         @csr                     = csr
@@ -24,7 +25,7 @@ module GlobalSign
       def params
         _params = {
           OrderRequestParameter: {
-            ProductCode: 'DV_LOW_URL',
+            ProductCode: @product_code,
             OrderKind:   @order_kind,
             Licenses:    1,
             ValidityPeriod: {

--- a/spec/global_sign/client_spec.rb
+++ b/spec/global_sign/client_spec.rb
@@ -26,6 +26,7 @@ describe GlobalSign::Client do
     context 'when received url_verification' do
       let(:url_verification_request) do
         GlobalSign::UrlVerification::Request.new(
+          product_code:           'DV_LOW_URL',
           order_kind:             'new',
           validity_period_months: 6,
           csr:                    'xxxxx',

--- a/spec/global_sign/request_spec.rb
+++ b/spec/global_sign/request_spec.rb
@@ -12,6 +12,7 @@ describe GlobalSign::Request do
 
   let(:request) do
     GlobalSign::UrlVerification::Request.new(
+      product_code:           'DV_LOW_URL',
       order_kind:             'new',
       validity_period_months: 6,
       csr:                    'xxxxx',

--- a/spec/global_sign/request_xml_builder_spec.rb
+++ b/spec/global_sign/request_xml_builder_spec.rb
@@ -13,6 +13,7 @@ describe GlobalSign::RequestXmlBuilder do
 
     let(:request) do
       GlobalSign::UrlVerification::Request.new(
+        product_code:           'DV_LOW_URL',
         order_kind:             'new',
         validity_period_months: 6,
         csr:                    'xxxxx',

--- a/spec/global_sign/url_verification/response_spec.rb
+++ b/spec/global_sign/url_verification/response_spec.rb
@@ -45,6 +45,7 @@ describe GlobalSign::UrlVerification::Response do
 
       let(:request) do
         GlobalSign::UrlVerification::Request.new(
+          product_code:           'DV_LOW_URL',
           order_kind:             'new',
           validity_period_months: 6,
           csr:                    csr,
@@ -71,6 +72,7 @@ describe GlobalSign::UrlVerification::Response do
 
       let(:request) do
         GlobalSign::UrlVerification::Request.new(
+          product_code:           'DV_LOW_URL',
           order_kind:             'invalid_kind',
           validity_period_months: 6,
           csr:                    csr,
@@ -101,6 +103,7 @@ describe GlobalSign::UrlVerification::Response do
 
       let(:request) do
         GlobalSign::UrlVerification::Request.new(
+          product_code:            'DV_LOW_URL',
           order_kind:              'renewal',
           validity_period_months:  6,
           csr:                     csr,
@@ -128,6 +131,7 @@ describe GlobalSign::UrlVerification::Response do
 
       let(:request) do
         GlobalSign::UrlVerification::Request.new(
+          product_code:            'DV_LOW_URL',
           order_kind:              'renewal',
           validity_period_months:  6,
           csr:                     csr,


### PR DESCRIPTION
今まで、証明書発行のAPI `URLVerification` を叩くするときには、証明書の種類を `AlphaSSL` でリクエストを組み立てていましたが、証明書の種類を選択できたほうがなにかと便利なので、選択できるようにします。

DomainSSL の場合は `DV_HIGH_URL` 、 AlphaSSL の場合は `DV_LOW_URL` と指定すれば良いみたいです。

ref: https://www.globalsign.com/en/resources/apis/api-documentation
SSL API Documentation v4.3.5
9.13 ProductCodes