### PR TITLE
Release 2 1 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2.1.0
+− bug fix `GlobalSign::OrderGetterByOrderId::Request` NoMethodError: undefined method `text' for nil:NilClass
+
+## 2.1.0
 
 - Support GlobalSign API: DecodeCSR
 - Support GlobalSign API: DVDNSOrder & DVDNSVerificationForIssue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 2.1.0
-− bug fix `GlobalSign::OrderGetterByOrderId::Request` NoMethodError: undefined method `text' for nil:NilClass
+## 2.1.1
+- Fixed bug: `GlobalSign::OrderGetterByOrderId::Request` NoMethodError: undefined method `text' for nil:NilClass
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.1.1
-- Fixed bug: `GlobalSign::OrderGetterByOrderId::Request` NoMethodError: undefined method `text' for nil:NilClass
+- Fixed bug: `GlobalSign::OrderGetterByOrderId::Request` NoMethodError: undefined method `text` for nil:NilClass
 
 ## 2.1.0
 

--- a/lib/global_sign/version.rb
+++ b/lib/global_sign/version.rb
@@ -1,3 +1,3 @@
 module GlobalSign
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
### 2.1.1の修正点

GlobalSign::OrderGetterByOrderId::Request にて、
NoMethodError: undefined method `text' for nil:NilClassとなる不具合の修正