### PR TITLE
Refactor response_class

### DIFF
--- a/lib/global_sign/client.rb
+++ b/lib/global_sign/client.rb
@@ -24,26 +24,9 @@ module GlobalSign
     end
 
     def find_response_class_for(request)
-      case request
-      when GlobalSign::CsrDecoder::Request
-        GlobalSign::CsrDecoder::Response
-      when GlobalSign::DnsVerification::Request
-        GlobalSign::DnsVerification::Response
-      when GlobalSign::DnsVerificationForIssue::Request
-        GlobalSign::DnsVerificationForIssue::Response
-      when GlobalSign::UrlVerification::Request
-        GlobalSign::UrlVerification::Response
-      when GlobalSign::UrlVerificationForIssue::Request
-        GlobalSign::UrlVerificationForIssue::Response
-      when GlobalSign::OrderGetterByOrderId::Request
-        GlobalSign::OrderGetterByOrderId::Response
-      when GlobalSign::DVApproverList::Request
-        GlobalSign::DVApproverList::Response
-      when GlobalSign::DVOrder::Request
-        GlobalSign::DVOrder::Response
-      else
-        raise ArgumentError, 'invalid request argument'
-      end
+      request.response_class
+    rescue
+      raise ArgumentError, 'invalid request argument'
     end
   end
 end

--- a/lib/global_sign/request.rb
+++ b/lib/global_sign/request.rb
@@ -19,5 +19,15 @@ module GlobalSign
         }
       }
     end
+
+    def response_class
+      class_namespace::Response
+    end
+
+    private
+
+    def class_namespace
+      self.class.to_s.deconstantize.constantize
+    end
   end
 end


### PR DESCRIPTION
To avoid add a new line to each new class with request/response,  ask it which class it responds to.

By convention, it'll look in its namespace for the response class. 

This can be replaced by implementing the method `response_class` in the desired class