### PR TITLE
Bump up version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+
+- Added `options` optional keyword argument to `GlobalSign::Client`
+  - It supports `timeout` which specifies number of seconds to wait for request
+
 ## 2.1.1
 - Fixed bug: `GlobalSign::OrderGetterByOrderId::Request` NoMethodError: undefined method `text` for nil:NilClass
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ response = client.process(request)
 puts response.params # => { common_name: "www.example.com", ... }
 ```
 
+### Client options
+
+`GlobalSign::Client` allows `options` argument in order to specify its behavior.  
+For now, it supports `timeout` which specifies number of seconds to wait for request.
+
+```ruby
+client = GlobalSign::Client.new(options: { timeout: 120 })
+```
+
 ## Contributing
 
 1. Create your feature branch (git checkout -b my-new-feature)

--- a/lib/global_sign/version.rb
+++ b/lib/global_sign/version.rb
@@ -1,3 +1,3 @@
 module GlobalSign
-  VERSION = "2.1.1"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
This PR releases [timeout opetion](https://github.com/pepabo/global_sign/pull/22) as v2.2.0 🎉 