### PR TITLE
Update status badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GlobalSign
 
 [![Gem Version](https://badge.fury.io/rb/global_sign.svg)](https://badge.fury.io/rb/global_sign)
-[![wercker status](https://app.wercker.com/status/8cf8771f0da8bc4f1ea0adc8eb65b295/s/master "wercker status")](https://app.wercker.com/project/byKey/8cf8771f0da8bc4f1ea0adc8eb65b295)
+![CI](https://github.com/pepabo/global_sign/workflows/CI/badge.svg?branch=master)
 
 A Ruby interface to the [GlobalSign](https://www.globalsign.com/) API.
 


### PR DESCRIPTION
GlobalSign gem is moving to GitHub Actions. So, the status badge is also used for that.
