### PR TITLE
Bump up version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+- Support GlobalSign API: EVOrder
+
 ## 2.2.0
 
 - Added `options` optional keyword argument to `GlobalSign::Client`

--- a/lib/global_sign/version.rb
+++ b/lib/global_sign/version.rb
@@ -1,3 +1,3 @@
 module GlobalSign
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
This PR releases [Support EVOrder](https://github.com/pepabo/global_sign/pull/25) as v2.3.0 :rocket:
