### PR TITLE
Fix error on activesupport 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.7, 3.0, 3.1, 3.2]
+        gemfile: ["active_support_6", "active_support_7"]
 
     runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
 
     steps:
     - uses: actions/checkout@v2
@@ -18,5 +22,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        cache-version: ${{ matrix.gemfile }}
 
     - run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: ruby/setup-ruby@v1.64.1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.7, 3.0]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0]
+        ruby: [2.7, 3.0, 3.1, 3.2]
 
     runs-on: ubuntu-latest
 

--- a/gemfiles/active_support_6.gemfile
+++ b/gemfiles/active_support_6.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'activesupport', "~> 6.0"
+
+# Specify your gem's dependencies in global_sign.gemspec
+gemspec path: '../'

--- a/gemfiles/active_support_7.gemfile
+++ b/gemfiles/active_support_7.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'activesupport', "~> 7.0"
+
+# Specify your gem's dependencies in global_sign.gemspec
+gemspec path: '../'

--- a/lib/global_sign.rb
+++ b/lib/global_sign.rb
@@ -1,4 +1,5 @@
-require 'active_support/core_ext/hash/conversions'
+require 'active_support'
+require 'active_support/core_ext'
 
 require 'global_sign/version'
 require 'global_sign/client'


### PR DESCRIPTION
In activesupport 7.x there was a change in the required require as shown in https://github.com/rails/rails/issues/43851 .If you require each of them, it will look like this.

```
require 'active_support/core_ext/hash/conversions'
require 'active_support/isolated_execution_state'
require 'active_support/xml_mini'
```

But, in many use cases of this gem, ActiveSupport is already loaded, so I decided to use require 'activesupport'.